### PR TITLE
fixed element deletion / upgraded ODB

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-client</artifactId>
-            <version>2.1.0</version>
+            <version>2.1.2</version>
         </dependency>
         <!-- TESTING -->
          <dependency>

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientEdgeIterator.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientEdgeIterator.java
@@ -14,14 +14,15 @@ import org.apache.tinkerpop.gremlin.structure.Direction;
 import java.util.Iterator;
 
 public class OrientEdgeIterator extends OLazyWrapperIterator<OrientEdge> {
-    private final OrientVertex             sourceVertex;
-    private final OrientVertex             targetVertex;
+    private final OrientVertex sourceVertex;
+    private final OrientVertex targetVertex;
     private final OPair<Direction, String> connection;
-    private final String[]                 labels;
+    private final String[] labels;
 
-    public OrientEdgeIterator(final OrientVertex iSourceVertex, final OrientVertex iTargetVertex, final Iterator<?> iterator,
+    public OrientEdgeIterator(final OrientVertex iSourceVertex, final OrientVertex iTargetVertex,
+                              final Object iMultiValue, final Iterator<?> iterator,
                               final OPair<Direction, String> connection, final String[] iLabels, final int iSize) {
-        super(iterator, iSize);
+        super(iterator, iSize, iMultiValue);
         this.sourceVertex = iSourceVertex;
         this.targetVertex = iTargetVertex;
         this.connection = connection;
@@ -51,9 +52,9 @@ public class OrientEdgeIterator extends OLazyWrapperIterator<OrientEdge> {
         if (!(record instanceof ODocument)) {
             // SKIP IT
             OLogManager.instance().warn(this,
-                    "Found a record (%s) that is not an edge. Source vertex : %s, Target vertex : %s, Database : %s .", rec,
-                    sourceVertex != null ? sourceVertex.id() : null, targetVertex != null ? targetVertex.id() : null,
-                    record.getDatabase().getURL());
+                "Found a record (%s) that is not an edge. Source vertex : %s, Target vertex : %s, Database : %s .", rec,
+                sourceVertex != null ? sourceVertex.id() : null, targetVertex != null ? targetVertex.id() : null,
+                record.getDatabase().getURL());
             return null;
         }
 
@@ -82,10 +83,10 @@ public class OrientEdgeIterator extends OLazyWrapperIterator<OrientEdge> {
 //          DIRECT VERTEX, CREATE DUMMY EDGE
             if (connection.getKey() == Direction.OUT)
                 edge = new OrientEdge(this.sourceVertex.getGraph(), (OIdentifiable) this.sourceVertex.id(), rec.getIdentity(),
-                        connection.getValue());
+                    connection.getValue());
             else
                 edge = new OrientEdge(this.sourceVertex.getGraph(), rec.getIdentity(), (OIdentifiable) this.sourceVertex.id(),
-                        connection.getValue());
+                    connection.getValue());
         } else if (immutableSchema.isEdgeType()) {
             edge = new OrientEdge(this.sourceVertex.getGraph(), rec.getIdentity(), connection.getValue());
         } else
@@ -106,5 +107,10 @@ public class OrientEdgeIterator extends OLazyWrapperIterator<OrientEdge> {
 //            return false;
 //
 //        return this.sourceVertex.settings.isUseVertexFieldsForEdgeLabels() || iObject.isLabeled(labels);
+    }
+
+    @Override
+    public boolean canUseMultiValueDirectly() {
+        return true;
     }
 }

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientElement.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientElement.java
@@ -1,6 +1,7 @@
 package org.apache.tinkerpop.gremlin.orientdb;
 
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
+import com.orientechnologies.orient.core.db.record.ORecordElement;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -46,7 +47,11 @@ public class OrientElement implements Element {
     }
 
     public void remove() {
-        getRawDocument().delete();
+        ODocument doc = getRawDocument();
+        if (doc.getInternalStatus() == ORecordElement.STATUS.NOT_LOADED) {
+            doc.load();
+        }
+        doc.delete();
     }
 
     public <V> Iterator<? extends Property<V>> properties(final String... propertyKeys) {

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientVertex.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientVertex.java
@@ -71,12 +71,12 @@ public final class OrientVertex extends OrientElement implements Vertex {
                     } else {
                         // CREATE LAZY Iterable AGAINST COLLECTION FIELD
                         if (coll instanceof ORecordLazyMultiValue)
-                            iterable.add(new OrientVertexIterator(this, ((ORecordLazyMultiValue) coll).rawIterator(), connection, labels, ((ORecordLazyMultiValue) coll).size()));
+                            iterable.add(new OrientVertexIterator(this, coll, ((ORecordLazyMultiValue) coll).rawIterator(), connection, labels, ((ORecordLazyMultiValue) coll).size()));
                         else
-                            iterable.add(new OrientVertexIterator(this, coll.iterator(), connection, labels, -1));
+                            iterable.add(new OrientVertexIterator(this, coll, coll.iterator(), connection, labels, -1));
                     }
                 } else if (fieldValue instanceof ORidBag) {
-                    iterable.add(new OrientVertexIterator(this, ((ORidBag) fieldValue).rawIterator(), connection, labels, -1));
+                    iterable.add(new OrientVertexIterator(this, fieldValue, ((ORidBag) fieldValue).rawIterator(), connection, labels, -1));
                 }
         }
 
@@ -306,12 +306,12 @@ public final class OrientVertex extends OrientElement implements Vertex {
                     } else {
                         // CREATE LAZY Iterable AGAINST COLLECTION FIELD
                         if (coll instanceof ORecordLazyMultiValue) {
-                            iterable.add(new OrientEdgeIterator(this, iDestination, ((ORecordLazyMultiValue) coll).rawIterator(), connection, edgeLabels, ((ORecordLazyMultiValue) coll).size()));
+                            iterable.add(new OrientEdgeIterator(this, iDestination, coll, ((ORecordLazyMultiValue) coll).rawIterator(), connection, edgeLabels, ((ORecordLazyMultiValue) coll).size()));
                         } else
-                            iterable.add(new OrientEdgeIterator(this, iDestination, coll.iterator(), connection, edgeLabels, -1));
+                            iterable.add(new OrientEdgeIterator(this, iDestination, coll, coll.iterator(), connection, edgeLabels, -1));
                     }
                 } else if (fieldValue instanceof ORidBag) {
-                    iterable.add(new OrientEdgeIterator(this, iDestination, ((ORidBag) fieldValue).rawIterator(), connection, edgeLabels, ((ORidBag) fieldValue).size()));
+                    iterable.add(new OrientEdgeIterator(this, iDestination, fieldValue, ((ORidBag) fieldValue).rawIterator(), connection, edgeLabels, ((ORidBag) fieldValue).size()));
                 }
             }
         }
@@ -406,12 +406,16 @@ public final class OrientVertex extends OrientElement implements Vertex {
         return OrientEdgeType.CLASS_NAME;
     }
 
-    protected void addSingleEdge(final ODocument doc, final OMultiCollectionIterator<Edge> iterable, String fieldName, final OPair<Direction, String> connection, final Object fieldValue, final OIdentifiable iTargetVertex, final String[] iLabels) {
+    protected void addSingleEdge(final ODocument doc, final OMultiCollectionIterator<Edge> iterable, String fieldName,
+                                 final OPair<Direction, String> connection, final Object fieldValue,
+                                 final OIdentifiable iTargetVertex, final String[] iLabels) {
         final OrientEdge toAdd = getEdge(graph, doc, fieldName, connection, fieldValue, iTargetVertex, iLabels);
         iterable.add(toAdd);
     }
 
-    protected static OrientEdge getEdge(final OrientGraph graph, final ODocument doc, String fieldName, final OPair<Direction, String> connection, final Object fieldValue, final OIdentifiable iTargetVertex, final String[] iLabels) {
+    protected static OrientEdge getEdge(final OrientGraph graph, final ODocument doc, String fieldName,
+                                        final OPair<Direction, String> connection, final Object fieldValue,
+                                        final OIdentifiable iTargetVertex, final String[] iLabels) {
         final OrientEdge toAdd;
 
         final ODocument fieldRecord = ((OIdentifiable) fieldValue).getRecord();
@@ -446,7 +450,8 @@ public final class OrientVertex extends OrientElement implements Vertex {
     }
 
 
-    private void addSingleVertex(final ODocument doc, final OMultiCollectionIterator<Vertex> iterable, String fieldName, final OPair<Direction, String> connection, final Object fieldValue, final String[] iLabels) {
+    private void addSingleVertex(final ODocument doc, final OMultiCollectionIterator<Vertex> iterable, String fieldName,
+                                 final OPair<Direction, String> connection, final Object fieldValue, final String[] iLabels) {
         final OrientVertex toAdd;
 
         final ODocument fieldRecord = ((OIdentifiable) fieldValue).getRecord();

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientVertexIterator.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientVertexIterator.java
@@ -2,14 +2,16 @@ package org.apache.tinkerpop.gremlin.orientdb;
 
 import com.orientechnologies.common.util.OPair;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
+import com.orientechnologies.orient.core.db.record.ridbag.ORidBag;
 import com.orientechnologies.orient.core.iterator.OLazyWrapperIterator;
-import org.apache.tinkerpop.gremlin.structure.Direction;
 import com.orientechnologies.orient.core.metadata.schema.OImmutableClass;
 import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.record.impl.ODocumentInternal;
+import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
+import java.util.Collection;
 import java.util.Iterator;
 
 public class OrientVertexIterator extends OLazyWrapperIterator<Vertex> {
@@ -17,9 +19,9 @@ public class OrientVertexIterator extends OLazyWrapperIterator<Vertex> {
     private final String[]                 iLabels;
     private final OPair<Direction, String> connection;
 
-    public OrientVertexIterator(final OrientVertex orientVertex, final Iterator<?> iterator,
+    public OrientVertexIterator(final OrientVertex orientVertex, final Object iMultiValue, final Iterator<?> iterator,
                                 final OPair<Direction, String> connection, final String[] iLabels, final int iSize) {
-        super(iterator, iSize);
+        super(iterator, iSize, iMultiValue);
         this.vertex = orientVertex;
         this.connection = connection;
         this.iLabels = iLabels;
@@ -89,5 +91,38 @@ public class OrientVertexIterator extends OLazyWrapperIterator<Vertex> {
             return false;
         }
         return true;
+    }
+
+    private boolean isVertex(final OIdentifiable iObject) {
+        final ORecord rec = iObject.getRecord();
+
+        if (rec == null || !(rec instanceof ODocument))
+            return false;
+
+        final ODocument value = (ODocument) rec;
+
+        final OIdentifiable v;
+        OImmutableClass immutableClass = ODocumentInternal.getImmutableSchemaClass(value);
+        if (immutableClass.isVertexType()) {
+            // DIRECT VERTEX
+            return true;
+        } else if (immutableClass.isEdgeType()) {
+            return false;
+        }
+
+        throw new IllegalStateException("Invalid content found between connections: " + value);
+    }
+
+    @Override
+    public boolean canUseMultiValueDirectly() {
+        if (multiValue instanceof Collection) {
+            if ((((Collection) multiValue).isEmpty()) || isVertex((OIdentifiable) ((Collection) multiValue).iterator().next()))
+                return true;
+        } else if (multiValue instanceof ORidBag) {
+            if ((((ORidBag) multiValue).isEmpty()) || isVertex(((ORidBag) multiValue).iterator().next()))
+                return true;
+        }
+
+        return false;
     }
 }

--- a/tests-scala/build.sbt
+++ b/tests-scala/build.sbt
@@ -2,7 +2,7 @@ name := "orientdb-tp3-test"
 organization := "com.michaelpollmeier"
 version := "1.0.0-SNAPSHOT"
 scalaVersion := "2.11.7"
-val orientDBVersion = "2.1.0"
+val orientDBVersion = "2.1.2"
 
 fork := true // if OrientDb version > 2.1-RC5
 


### PR DESCRIPTION
* Ensure that a graph element is loaded before attempting deletion. (Could not reproduce the case in the test suite yet, but it is a problem).
* Upgraded to OrientDB 2.1.2. The interface changed, so there is some new code copied over from the TP2 driver.
* Refactored test suite for quickly alternating between memory / remote instances.
