### PR TITLE
when saving multiple properties, only save at the end

### DIFF
--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientElement.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientElement.java
@@ -5,11 +5,7 @@ import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.metadata.schema.OImmutableClass;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Element;
-import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.Property;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.*;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -56,6 +52,10 @@ public abstract class OrientElement implements Element {
     }
 
     public <V> Property<V> property(final String key, final V value) {
+        return property(key, value, true); //save after setting
+    }
+
+    private <V> Property<V> property(final String key, final V value, boolean saveDocument) {
         if(key == null)
             throw Property.Exceptions.propertyKeyCanNotBeNull();
         if(value == null)
@@ -65,7 +65,10 @@ public abstract class OrientElement implements Element {
 
         ODocument doc = getRawDocument();
         doc.field(key, value);
-        doc.save();
+
+        // when setting multiple properties at once, it makes sense to only save them in the end
+        // for performance reasons and so that the schema checker only kicks in at the end
+        if (saveDocument) doc.save();
         return new OrientProperty<>(key, value, this);
     }
 
@@ -73,7 +76,13 @@ public abstract class OrientElement implements Element {
         ElementHelper.legalPropertyKeyValueArray(keyValues);
         if (ElementHelper.getIdValue(keyValues).isPresent()) throw Vertex.Exceptions.userSuppliedIdsNotSupported();
 
-        ElementHelper.attachProperties(this, keyValues);
+        // copied from ElementHelper.attachProperties
+        // can't use ElementHelper here because we only want to save the document at the very end
+        for (int i = 0; i < keyValues.length; i = i + 2) {
+            if (!keyValues[i].equals(T.id) && !keyValues[i].equals(T.label))
+                property((String) keyValues[i], keyValues[i + 1], false);
+        }
+        getRawDocument().save();
     }
 
     public <V> Iterator<? extends Property<V>> properties(final String... propertyKeys) {


### PR DESCRIPTION
* to ensure integrity checks are only performed at the end
* to gain speed