### PR TITLE
Support for UNIQUE and NOTUNIQUE indices on edges.

### DIFF
--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientEdge.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientEdge.java
@@ -49,6 +49,10 @@ public final class OrientEdge extends OrientElement implements Edge {
         this(graph, rawDocument, rawDocument.getClassName());
     }
 
+    public OrientEdge(final OrientGraph graph, final OIdentifiable rawElement) {
+        this(graph, (rawElement instanceof ODocument) ? ((ODocument) rawElement) : new ODocument(rawElement.getIdentity()));
+    }
+
     public static OIdentifiable getConnection(final ODocument iEdgeRecord, final Direction iDirection) {
         return iEdgeRecord.rawField(iDirection == Direction.OUT ? OrientGraphUtils.CONNECTION_OUT : OrientGraphUtils.CONNECTION_IN);
     }

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
@@ -263,15 +263,15 @@ public final class OrientGraph implements Graph {
     }
 
     public Stream<OrientVertex> getIndexedVertices(OIndex<Object> index, Optional<Object> valueOption) {
-        return getIndexedElements(index, valueOption, OrientVertex::new, OrientVertex::new);
+        return getIndexedElements(index, valueOption, OrientVertex::new);
     }
 
     public Stream<OrientEdge> getIndexedEdges(OIndex<Object> index, Optional<Object> valueOption) {
-        return getIndexedElements(index, valueOption, OrientEdge::new, OrientEdge::new);
+        return getIndexedElements(index, valueOption, OrientEdge::new);
     }
 
     private <ElementType extends OrientElement> Stream<ElementType> getIndexedElements(OIndex<Object> index, Optional<Object> valueOption,
-            BiFunction<OrientGraph, OIdentifiable, ElementType> newElementById, BiFunction<OrientGraph, ODocument, ElementType> newElementByDoc) {
+            BiFunction<OrientGraph, OIdentifiable, ElementType> newElement) {
         return executeWithConnectionCheck(() -> {
             makeActive();
 
@@ -280,7 +280,7 @@ public final class OrientGraph implements Graph {
                 return Collections.<ElementType> emptyList().stream();
             } else {
                 if (!valueOption.isPresent()) {
-                    return index.cursor().toValues().stream().map(id -> newElementById.apply(this, id));
+                    return index.cursor().toValues().stream().map(id -> newElement.apply(this, id));
                 } else {
                     Object value = convertValue(index, valueOption.get());
                     Object indexValue = index.get(value);
@@ -298,7 +298,7 @@ public final class OrientGraph implements Graph {
                     Iterable<OIdentifiable> iterableVals = (Iterable<OIdentifiable>) indexValue;
                     Stream<OIdentifiable> ids = StreamSupport.stream(iterableVals.spliterator(), false);
                     Stream<ORecord> records = ids.map(id -> (ORecord) id.getRecord()).filter(r -> r != null);
-                    return records.map(r -> newElementByDoc.apply(this, getRawDocument(r)));
+                    return records.map(r -> newElement.apply(this, getRawDocument(r)));
                 }
             }
         });

--- a/driver/src/test/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraphIndexTest.java
+++ b/driver/src/test/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraphIndexTest.java
@@ -1,6 +1,7 @@
 package org.apache.tinkerpop.gremlin.orientdb;
 
 import com.orientechnologies.orient.core.index.OIndex;
+import com.orientechnologies.orient.core.metadata.schema.OClass;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.storage.ORecordDuplicatedException;
 import org.apache.commons.configuration.BaseConfiguration;
@@ -26,8 +27,12 @@ public class OrientGraphIndexTest {
         return new OrientGraphFactory(URL + UUID.randomUUID(), "root", "root").getNoTx();
     }
 
-    String label1 = "SomeVertexLabel1";
-    String label2 = "SomeVertexLabel2";
+    String vertexLabel1 = "SomeVertexLabel1";
+    String vertexLabel2 = "SomeVertexLabel2";
+
+    String edgeLabel1 = "SomeEdgeLabel1";
+    String edgeLabel2 = "SomeEdgeLabel2";
+
     String key = "indexedKey";
 
     @Test
@@ -36,92 +41,146 @@ public class OrientGraphIndexTest {
         createVertexIndexLabel1(graph);
         String value = "value1";
 
-        graph.addVertex(T.label, label1, key, value);
-        graph.addVertex(T.label, label2, key, value);
+        graph.addVertex(T.label, vertexLabel1, key, value);
+        graph.addVertex(T.label, vertexLabel2, key, value);
 
         // no duplicates allowed for vertex with label1
         try {
-            graph.addVertex(T.label, label1, key, value);
+            graph.addVertex(T.label, vertexLabel1, key, value);
             Assert.fail("must throw duplicate key here!");
         } catch (ORecordDuplicatedException e) {
             // ok
         }
 
         // allow duplicate for vertex with label2
-        graph.addVertex(T.label, label2, key, value);
+        graph.addVertex(T.label, vertexLabel2, key, value);
     }
 
     @Test
-    public void vertexIndexLookupWithValue() {
+    public void edgeUniqueConstraint() {
+        OrientGraph graph = newGraph();
+        createUniqueEdgeIndex(graph, edgeLabel1);
+        String value = "value1";
+
+        Vertex v1 = graph.addVertex(T.label, vertexLabel1);
+        Vertex v2 = graph.addVertex(T.label, vertexLabel1);
+        v1.addEdge(edgeLabel1, v2, key, value);
+
+        // no duplicates allowed for edge with label1
+        try {
+            v1.addEdge(edgeLabel1, v2, key, value);
+            Assert.fail("must throw duplicate key here!");
+        } catch (ORecordDuplicatedException e) {
+            // ok
+        }
+
+        // allow duplicate for vertex with label2
+        v2.addEdge(edgeLabel2, v1, key, value);
+    }
+
+    @Test
+    public void vertexUniqueIndexLookupWithValue() {
         OrientGraph graph = newGraph();
         createVertexIndexLabel1(graph);
         String value = "value1";
 
         // verify index created
-        Assert.assertEquals(graph.getIndexedKeys(Vertex.class, label1), new HashSet<>(Collections.singletonList(key)));
-        Assert.assertEquals(graph.getIndexedKeys(Vertex.class, label2), new HashSet<>(Collections.emptyList()));
-        Assert.assertEquals(graph.getIndexedKeys(Edge.class, label1), new HashSet<>(Collections.emptyList()));
+        Assert.assertEquals(graph.getIndexedKeys(Vertex.class, vertexLabel1), new HashSet<>(Collections.singletonList(key)));
+        Assert.assertEquals(graph.getIndexedKeys(Vertex.class, vertexLabel2), new HashSet<>(Collections.emptyList()));
+        Assert.assertEquals(graph.getIndexedKeys(Edge.class, vertexLabel1), new HashSet<>(Collections.emptyList()));
 
-        Vertex v1 = graph.addVertex(T.label, label1, key, value);
-        Vertex v2 = graph.addVertex(T.label, label2, key, value);
+        Vertex v1 = graph.addVertex(T.label, vertexLabel1, key, value);
+        Vertex v2 = graph.addVertex(T.label, vertexLabel2, key, value);
 
         // looking deep into the internals here - I can't find a nicer way to
         // auto verify that an index is actually used
-        GraphTraversal<Vertex, Vertex> traversal = graph.traversal().V().has(T.label, P.eq(label1)).has(key, P.eq(value));
-        OrientGraphStepStrategy.instance().apply(traversal.asAdmin());
+        GraphTraversal<Vertex, Vertex> traversal = graph.traversal().V().has(T.label, P.eq(vertexLabel1)).has(key, P.eq(value));
 
-        OrientGraphStep orientGraphStep = (OrientGraphStep) traversal.asAdmin().getStartStep();
-        OrientIndexQuery orientIndexQuery = (OrientIndexQuery) orientGraphStep.findIndex().get();
-
-        OIndex index = orientIndexQuery.index;
+        OIndex index = findUsedIndex(traversal).get().index;
         Assert.assertEquals(1, index.getSize());
         Assert.assertEquals(v1.id(), index.get(value));
+
+        List<Vertex> result = traversal.toList();
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(v1.id(), result.get(0).id());
     }
 
-    // Indexed edge properties is not yet handled / implemented.
-    //    @Test
-    //    public void uniqueIndexOnEdges() {
-    //
-    //        String vertexLabel = "SomeVertexLabel";
-    //        String edgeLabel1 = "SomeEdgeLabel1";
-    //        String edgeLabel2 = "SomeEdgeLabel2";
-    //        String indexedKey = "indexedKey";
-    //        String value = "value1";
-    //
-    //        OrientGraph graph = newGraph();
-    //
-    //        Configuration config = new BaseConfiguration();
-    //        config.setProperty("type", "UNIQUE");
-    //        config.setProperty("keytype", OType.STRING);
-    //        graph.createEdgeIndex(indexedKey, edgeLabel1, config);
-    //
-    //        Assert.assertEquals(graph.getIndexedKeys(Edge.class, edgeLabel1), new HashSet<String>(Collections.singletonList(indexedKey)));
-    //        Assert.assertEquals(graph.getIndexedKeys(Edge.class, edgeLabel2), new HashSet<String>(Collections.emptyList()));
-    //        Assert.assertEquals(graph.getIndexedKeys(Vertex.class, vertexLabel), new HashSet<String>(Collections.emptyList()));
-    //
-    //        Vertex v1 = graph.addVertex(T.label, vertexLabel);
-    //        Vertex v2 = graph.addVertex(T.label, vertexLabel);
-    //        Edge e1 = v1.addEdge(edgeLabel1, v2, indexedKey, value);
-    //        Edge e2 = v1.addEdge(edgeLabel2, v2, indexedKey, value);
-    //
-    //        // Verify that the traversal hits the index via println debugging.
-    //        // Should print "index will be queried..." then "not indexed"
-    //        Set<Edge> result1 = graph.traversal().E().has(T.label, P.eq(edgeLabel1)).toSet();
-    //        Assert.assertTrue(result1.size() == 1);
-    //        Set<Edge> result2 = graph.traversal().E().has(T.label, P.eq(edgeLabel2)).toSet();
-    //        Assert.assertTrue(result2.size() == 1);
-    //
-    //        // no duplicates allowed for edge with label1
-    //        try {
-    //            v2.addEdge(edgeLabel1, v1, indexedKey, value);
-    //            Assert.fail("must throw duplicate key here!");
-    //        } catch (ORecordDuplicatedException e) {
-    //            // ok
-    //        }
-    //
-    //        // allow duplicate for vertex with label2
-    //        v2.addEdge(edgeLabel2, v1, indexedKey, value);
-    //    }
+    @Test
+    public void edgeUniqueIndexLookupWithValue() {
+        OrientGraph graph = newGraph();
+        createUniqueEdgeIndex(graph, edgeLabel1);
+        String value = "value1";
+
+        Assert.assertEquals(graph.getIndexedKeys(Edge.class, edgeLabel1), new HashSet<>(Collections.singletonList(key)));
+        Assert.assertEquals(graph.getIndexedKeys(Edge.class, edgeLabel2), new HashSet<>(Collections.emptyList()));
+        Assert.assertEquals(graph.getIndexedKeys(Vertex.class, vertexLabel1), new HashSet<>(Collections.emptyList()));
+
+        Vertex v1 = graph.addVertex(T.label, vertexLabel1);
+        Vertex v2 = graph.addVertex(T.label, vertexLabel1);
+        Edge e1 = v1.addEdge(edgeLabel1, v2, key, value);
+        Edge e2 = v1.addEdge(edgeLabel2, v2, key, value);
+
+        {
+            // Verify that the traversal hits the index for the edges with label1
+            GraphTraversal<Edge, Edge> traversal1 = graph.traversal().E().has(T.label, P.eq(edgeLabel1)).has(key, P.eq(value));
+            Optional<OrientIndexQuery> orientIndexQuery = findUsedIndex(traversal1);
+            Assert.assertTrue(orientIndexQuery.isPresent());
+
+            OIndex index = orientIndexQuery.get().index;
+            Assert.assertEquals(1, index.getSize());
+            Assert.assertEquals(e1.id(), index.get(value));
+
+            List<Edge> result1 = traversal1.toList();
+            Assert.assertEquals(1, result1.size());
+            Assert.assertEquals(e1.id(), result1.get(0).id());
+        }
+
+        {
+            // Verify that the traversal doesn't try to hit the index for the edges with label2
+            GraphTraversal<Edge, Edge> traversal2 = graph.traversal().E().has(T.label, P.eq(edgeLabel2)).has(key, P.eq(value));
+            Assert.assertFalse(findUsedIndex(traversal2).isPresent());
+
+            List<Edge> result2 = traversal2.toList();
+            Assert.assertEquals(1, result2.size());
+            Assert.assertEquals(e2.id(), result2.get(0).id());
+        }
+    }
+
+    @Test
+    public void edgeNotUniqueIndexLookupWithValue() {
+        OrientGraph graph = newGraph();
+
+        createNotUniqueEdgeIndex(graph, edgeLabel1);
+
+        String value = "value1";
+
+        Assert.assertEquals(graph.getIndexedKeys(Edge.class, edgeLabel1), new HashSet<>(Collections.singletonList(key)));
+        Assert.assertEquals(graph.getIndexedKeys(Edge.class, edgeLabel2), new HashSet<>(Collections.emptyList()));
+        Assert.assertEquals(graph.getIndexedKeys(Vertex.class, vertexLabel1), new HashSet<>(Collections.emptyList()));
+
+        Vertex v1 = graph.addVertex(T.label, vertexLabel1);
+        Vertex v2 = graph.addVertex(T.label, vertexLabel1);
+        Edge e1 = v1.addEdge(edgeLabel1, v2, key, value);
+        Edge e2 = v1.addEdge(edgeLabel1, v2, key, value);
+        Edge e3 = v1.addEdge(edgeLabel1, v2);
+
+        // Verify that the traversal hits the index for the edges with label1
+        GraphTraversal<Edge, Edge> traversal1 = graph.traversal().E().has(T.label, P.eq(edgeLabel1)).has(key, P.eq(value));
+        Optional<OrientIndexQuery> orientIndexQuery = findUsedIndex(traversal1);
+        Assert.assertTrue(orientIndexQuery.isPresent());
+
+        OIndex index = orientIndexQuery.get().index;
+        Assert.assertEquals(2, index.getSize());
+        Assert.assertTrue(((Collection) index.get(value)).contains(e1.id()));
+        Assert.assertTrue(((Collection) index.get(value)).contains(e2.id()));
+        Assert.assertFalse(((Collection) index.get(value)).contains(e3.id()));
+
+        List<Edge> result1 = traversal1.toList();
+        Assert.assertEquals(2, result1.size());
+        Assert.assertTrue(result1.stream().map(Edge::id).anyMatch(e1.id()::equals));
+        Assert.assertTrue(result1.stream().map(Edge::id).anyMatch(e2.id()::equals));
+        Assert.assertFalse(result1.stream().map(Edge::id).anyMatch(e3.id()::equals));
+    }
 
     //TODO: fix
     @Test
@@ -145,10 +204,33 @@ public class OrientGraphIndexTest {
         //        Assert.assertEquals(result.hasNext(), true);
     }
 
+    private Optional<OrientIndexQuery> findUsedIndex(GraphTraversal<?, ?> traversal) {
+        OrientGraphStepStrategy.instance().apply(traversal.asAdmin());
+
+        @SuppressWarnings("rawtypes")
+        OrientGraphStep orientGraphStep = (OrientGraphStep) traversal.asAdmin().getStartStep();
+
+        return orientGraphStep.findIndex();
+    }
+
     private void createVertexIndexLabel1(OrientGraph graph) {
         Configuration config = new BaseConfiguration();
         config.setProperty("type", "UNIQUE");
         config.setProperty("keytype", OType.STRING);
-        graph.createVertexIndex(key, label1, config);
+        graph.createVertexIndex(key, vertexLabel1, config);
+    }
+
+    private void createUniqueEdgeIndex(OrientGraph graph, String label) {
+        Configuration config = new BaseConfiguration();
+        config.setProperty("type", OClass.INDEX_TYPE.UNIQUE.name());
+        config.setProperty("keytype", OType.STRING);
+        graph.createEdgeIndex(key, label, config);
+    }
+
+    private void createNotUniqueEdgeIndex(OrientGraph graph, String label) {
+        Configuration config = new BaseConfiguration();
+        config.setProperty("type", OClass.INDEX_TYPE.NOTUNIQUE.name());
+        config.setProperty("keytype", OType.STRING);
+        graph.createEdgeIndex(key, label, config);
     }
 }


### PR DESCRIPTION
Hi there,

I just had a go at getting index support for edges. It largely follows the approach taken for vertex indices.

There's also a small fix in OrientGraph.java for a potential ClassCastException being thrown during index lookup when using a remote connection. This has the exact same exception message as in the old issue #71 and seems to happen when using a remote connection and a NOTUNIQUE index.

Cheers,
John