### PR TITLE
Use index for multiple provided values

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The main area that need some more work is index lookups - currently it does find
 * you can run the standard tinkerpop test suite with `mvn install -P release`
 * there are some additional tests that you can run independently with `mvn test`
 * additionally there is a separate suite of tests in the `tests-scala` directory which you can run using `sbt test`
+* to automatically format the code (travis CI enforces a format check), just run `mvn clean install`
 
 ## Usage
 Have a look at the tests-scala which demonstrates the usage. There's also an orientdb example project in [gremlin-scala-examples](https://github.com/mpollmeier/gremlin-scala-examples).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TP3 Graph Structure Implementation for OrientDB. This started off as just a proo
 
 Warning: While this is (as of now) the only TP3 graph structure implementation for OrientDB, it's not the `official` one - it's not supported by the Orient team. The contributors focused on the functionality needed for their use cases, and it doesn't claim to be complete. 
 
-The main area that need some more work is index lookups - currently it does find the right index for a simple case, e.g. `g.V.hasLabel("myLabel").has("someKey", "someValue")`. However if there are multiple indexes on the same property, or if there the traversal should better use a composite index, that's not handled well yet. If you feel inclined you can add these cases to the OrientGraphIndexTest.java.
+The main area that need some more work is index lookups - currently it does find the right index for a simple case, e.g. `g.V.hasLabel("myLabel").has("someKey", "someValue")`. However if there are multiple indexes on the same property, or if there the traversal should better use a composite index, that's not handled well yet. If you feel inclined you can add these cases to the `OrientGraphIndexTest.java`. The function that looks up indexes is `OrientGraphStep.findIndex`.
 
 ## Tests
 * you can run the standard tinkerpop test suite with `mvn install -P release`

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -175,7 +175,7 @@
             <plugin>
                 <groupId>com.marvinformatics.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>1.6.0.RC4</version>
+                <version>1.8.0</version>
                 <configuration>
                     <sourceDirectory>${project.basedir}</sourceDirectory>
                     <excludes>

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
@@ -90,7 +90,7 @@ public final class OrientGraph implements Graph {
         if (config.containsKey(CONFIG_POOL_SIZE))
             if (config.containsKey(CONFIG_MAX_PARTITION_SIZE))
             factory.setupPool(config.getInt(CONFIG_MAX_PARTITION_SIZE), config.getInt(CONFIG_POOL_SIZE));
-        else
+            else
                 factory.setupPool(config.getInt(CONFIG_POOL_SIZE));
 
         return factory.getNoTx();

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
@@ -284,10 +284,9 @@ public final class OrientGraph implements Graph {
                     return index.cursor().toValues().stream().map(id -> newElement.apply(this, id));
                 } else {
                     Stream<Object> convertedValues = StreamUtils.asStream(valuesIter).map(value -> convertValue(index, value));
-                    Stream<OIdentifiable> ids = convertedValues.flatMap(v -> lookupInIndex(index, v));
+                    Stream<OIdentifiable> ids = convertedValues.flatMap(v -> lookupInIndex(index, v)).filter(r -> r != null);
                     Stream<ORecord> records = ids.map(id -> id.getRecord());
-                    Stream<ORecord> recordsWithoutNulls = records.filter(r -> r != null);
-                    return recordsWithoutNulls.map(r -> newElement.apply(this, getRawDocument(r)));
+                    return records.map(r -> newElement.apply(this, getRawDocument(r)));
                 }
             }
         });

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
@@ -262,43 +262,32 @@ public final class OrientGraph implements Graph {
         return iValue;
     }
 
-    public Stream<OrientVertex> getIndexedVertices(OIndex<Object> index, Optional<Object> valueOption) {
-        return getIndexedElements(index, valueOption, OrientVertex::new);
+    public Stream<OrientVertex> getIndexedVertices(OIndex<Object> index, Iterator<Object> valueIter) {
+        return getIndexedElements(index, valueIter, OrientVertex::new);
     }
 
-    public Stream<OrientEdge> getIndexedEdges(OIndex<Object> index, Optional<Object> valueOption) {
-        return getIndexedElements(index, valueOption, OrientEdge::new);
+    public Stream<OrientEdge> getIndexedEdges(OIndex<Object> index, Iterator<Object> valueIter) {
+        return getIndexedElements(index, valueIter, OrientEdge::new);
     }
 
-    private <ElementType extends OrientElement> Stream<ElementType> getIndexedElements(OIndex<Object> index, Optional<Object> valueOption,
+    private <ElementType extends OrientElement> Stream<ElementType> getIndexedElements(
+            OIndex<Object> index,
+            Iterator<Object> valuesIter,
             BiFunction<OrientGraph, OIdentifiable, ElementType> newElement) {
         return executeWithConnectionCheck(() -> {
             makeActive();
 
             if (index == null) {
-                // NO INDEX
                 return Collections.<ElementType> emptyList().stream();
             } else {
-                if (!valueOption.isPresent()) {
+                if (!valuesIter.hasNext()) {
                     return index.cursor().toValues().stream().map(id -> newElement.apply(this, id));
                 } else {
-                    Object value = convertValue(index, valueOption.get());
-                    Object indexValue = index.get(value);
-                    if (indexValue == null) {
-                        return Collections.<ElementType> emptyList().stream();
-                    } else if (!(indexValue instanceof Iterable<?>)) {
-                        indexValue = Collections.singletonList(indexValue);
-                    }
-
-                    // The index value is iterable, but some indices will give ORecordId 
-                    // objects (e.g. OIndexTxAwareOneValue and OIndexTxAwareMultiValue) whilst others will 
-                    // give ORecord objects (e.g. OIndexRemoteMultiValue). 
-                    // Thankfully both ORecordId and ORecord implement OIdentifiable.
-                    @SuppressWarnings("unchecked")
-                    Iterable<OIdentifiable> iterableVals = (Iterable<OIdentifiable>) indexValue;
-                    Stream<OIdentifiable> ids = StreamSupport.stream(iterableVals.spliterator(), false);
-                    Stream<ORecord> records = ids.map(id -> (ORecord) id.getRecord()).filter(r -> r != null);
-                    return records.map(r -> newElement.apply(this, getRawDocument(r)));
+                    Stream<Object> convertedValues = StreamUtils.asStream(valuesIter).map(value -> convertValue(index, value));
+                    Stream<OIdentifiable> ids = convertedValues.map(v -> (OIdentifiable) index.get(v));
+                    Stream<ORecord> records = ids.map(id -> id.getRecord());
+                    Stream<ORecord> recordsWithoutNulls = records.filter(r -> r != null);
+                    return recordsWithoutNulls.map(r -> newElement.apply(this, getRawDocument(r)));
                 }
             }
         });

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientIndexQuery.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientIndexQuery.java
@@ -1,18 +1,20 @@
 package org.apache.tinkerpop.gremlin.orientdb;
 
 import com.orientechnologies.orient.core.index.OIndex;
+
+import java.util.Iterator;
 import java.util.Optional;
 
 public class OrientIndexQuery {
-    public final Optional<Object> value;
+    public final Iterator<Object> values;
     public final OIndex index;
 
-    public OrientIndexQuery(OIndex index, Optional<Object> value) {
+    public OrientIndexQuery(OIndex index, Iterator<Object> values) {
         this.index = index;
-        this.value = value;
+        this.values = values;
     }
 
     public String toString() {
-        return "OrientIndexQuery(index=" + index + ", value=" + value + ")";
+        return "OrientIndexQuery(index=" + index + ")";
     }
 }

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientVertexProperty.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientVertexProperty.java
@@ -16,7 +16,7 @@ import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 
-public class OrientVertexProperty<V> extends OrientProperty<V>implements VertexProperty<V> {
+public class OrientVertexProperty<V> extends OrientProperty<V> implements VertexProperty<V> {
 
     public OrientVertexProperty(Property<V> property, OrientVertex vertex) {
         super(property.key(), property.value(), vertex);

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/traversal/step/sideEffect/OrientGraphStep.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/traversal/step/sideEffect/OrientGraphStep.java
@@ -29,7 +29,7 @@ import com.orientechnologies.orient.core.index.OIndex;
 import com.orientechnologies.orient.core.index.OIndexManagerProxy;
 import com.orientechnologies.orient.core.metadata.schema.OImmutableClass;
 
-public class OrientGraphStep<S, E extends Element> extends GraphStep<S, E>implements HasContainerHolder {
+public class OrientGraphStep<S, E extends Element> extends GraphStep<S, E> implements HasContainerHolder {
 
     private final List<HasContainer> hasContainers = new ArrayList<>();
 
@@ -68,8 +68,7 @@ public class OrientGraphStep<S, E extends Element> extends GraphStep<S, E>implem
      * @return An iterator for all the vertices/edges for this step
      */
     private <ElementType extends Element> Iterator<? extends ElementType> elements(
-            BiFunction<OrientGraph, Object[],
-            Iterator<ElementType>> getElementsByIds,
+            BiFunction<OrientGraph, Object[], Iterator<ElementType>> getElementsByIds,
             TriFunction<OrientGraph, OIndex<Object>, Iterator<Object>, Stream<? extends ElementType>> getElementsByIndex,
             Function<OrientGraph, Iterator<ElementType>> getAllElements) {
         final OrientGraph graph = getGraph();
@@ -130,9 +129,8 @@ public class OrientGraphStep<S, E extends Element> extends GraphStep<S, E>implem
             final Set<String> indexedKeys = classLabel.isPresent() ? graph.getIndexedKeys(this.returnClass, classLabel.get()) : graph.getIndexedKeys(this.returnClass);
 
             Optional<Pair<String, Iterator<Object>>> requestedKeyValue = this.hasContainers.stream()
-                    .filter(c -> indexedKeys.contains(c.getKey()) && (
-                            c.getPredicate().getBiPredicate() == Compare.eq ||
-                                    c.getPredicate().getBiPredicate() == Contains.within))
+                    .filter(c -> indexedKeys.contains(c.getKey()) && (c.getPredicate().getBiPredicate() == Compare.eq ||
+                            c.getPredicate().getBiPredicate() == Contains.within))
                     .findAny()
                     .map(c -> getValuePair(c))
                     .orElseGet(Optional::empty);
@@ -162,7 +160,7 @@ public class OrientGraphStep<S, E extends Element> extends GraphStep<S, E>implem
     private Optional<Pair<String, Iterator<Object>>> getValuePair(HasContainer c) {
         Iterator<Object> values;
         if (c.getPredicate().getBiPredicate() == Contains.within)
-            values = ((Iterable<Object>)c.getValue()).iterator();
+            values = ((Iterable<Object>) c.getValue()).iterator();
         else
             values = IteratorUtils.of(c.getValue());
         return Optional.of(new Pair<>(c.getKey(), values));


### PR DESCRIPTION
Adding index support when using `within` (multiple values)
@velo can you review this please?

Travis fails with this error, I'm certain you know what's going on there... can you document in the readme how to format the code properly?

```
[ERROR] Failed to execute goal com.marvinformatics.formatter:formatter-maven-plugin:1.6.0.RC4:validate (validate) on project orientdb-gremlin: File '/home/travis/build/mpollmeier/orientdb-gremlin/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/traversal/step/sideEffect/OrientGraphStep.java' format doesn't match! -> [Help 1]
```