### PR TITLE
Creating vertex label with correct prefix

### DIFF
--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientEdge.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientEdge.java
@@ -4,19 +4,18 @@ import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.db.record.ORecordElement;
 import com.orientechnologies.orient.core.db.record.ridbag.ORidBag;
 import com.orientechnologies.orient.core.record.impl.ODocument;
-
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class OrientEdge extends OrientElement implements Edge {
 
@@ -33,8 +32,8 @@ public final class OrientEdge extends OrientElement implements Edge {
         label = checkNotNull(iLabel, "label on edge " + rawElement);
     }
 
-    public OrientEdge(OrientGraph graph, String className, final OIdentifiable out, final OIdentifiable in, final String iLabel) {
-        this(graph, createRawElement(graph, className), out, in, iLabel);
+    public OrientEdge(OrientGraph graph, String label, final OIdentifiable out, final OIdentifiable in, final String iLabel) {
+        this(graph, createRawElement(graph, label), out, in, iLabel);
     }
 
     public OrientEdge(OrientGraph graph, final OIdentifiable out, final OIdentifiable in, final String iLabel) {
@@ -57,8 +56,8 @@ public final class OrientEdge extends OrientElement implements Edge {
         return iEdgeRecord.rawField(iDirection == Direction.OUT ? OrientGraphUtils.CONNECTION_OUT : OrientGraphUtils.CONNECTION_IN);
     }
 
-    protected static ODocument createRawElement(OrientGraph graph, String className) {
-        graph.createEdgeClass(className);
+    protected static ODocument createRawElement(OrientGraph graph, String label) {
+        String className = graph.createEdgeClass(label);
         return new ODocument(className);
     }
 

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
@@ -184,8 +184,7 @@ public final class OrientGraph implements Graph {
             if (ElementHelper.getIdValue(keyValues).isPresent()) throw Vertex.Exceptions.userSuppliedIdsNotSupported();
 
             String label = ElementHelper.getLabelValue(keyValues).orElse(OImmutableClass.VERTEX_CLASS_NAME);
-            String className = labelToClassName(label, OImmutableClass.VERTEX_CLASS_NAME);
-            OrientVertex vertex = new OrientVertex(this, className);
+            OrientVertex vertex = new OrientVertex(this, label);
             vertex.property(keyValues);
 
             vertex.save();
@@ -523,24 +522,18 @@ public final class OrientGraph implements Graph {
         }
     }
 
-    public void createVertexLabel(final String label){
+    public String createVertexClass(final String label) {
+        makeActive();
         String className = labelToClassName(label, OImmutableClass.VERTEX_CLASS_NAME);
-        createVertexClass(className);
-    }
-
-    public void createEdgeLabel(final String label){
-        String className = labelToClassName(label, OImmutableClass.EDGE_CLASS_NAME);
-        createEdgeClass(className);
-    }
-
-    public void createVertexClass(final String className) {
-        makeActive();
         createClass(className, OImmutableClass.VERTEX_CLASS_NAME);
+        return className;
     }
 
-    public void createEdgeClass(final String className) {
+    public String createEdgeClass(final String label) {
         makeActive();
+        String className = labelToClassName(label, OImmutableClass.EDGE_CLASS_NAME);
         createClass(className, OImmutableClass.EDGE_CLASS_NAME);
+        return className;
     }
 
     public void createClass(final String className, final String superClassName) {
@@ -605,13 +598,13 @@ public final class OrientGraph implements Graph {
 
     public <E extends Element> void createVertexIndex(final String key, final String label, final Configuration configuration) {
         String className = labelToClassName(label, OImmutableClass.VERTEX_CLASS_NAME);
-        createVertexClass(className);
+        createVertexClass(label);
         createIndex(key, className, configuration);
     }
 
     public <E extends Element> void createEdgeIndex(final String key, final String label, final Configuration configuration) {
         String className = labelToClassName(label, OImmutableClass.EDGE_CLASS_NAME);
-        createEdgeClass(className);
+        createEdgeClass(label);
         createIndex(key, className, configuration);
     }
 

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
@@ -31,12 +31,12 @@ import org.apache.tinkerpop.gremlin.structure.io.Io;
 import org.apache.tinkerpop.gremlin.structure.io.Io.Builder;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+
 import java.util.*;
-import java.util.function.Function;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static org.apache.tinkerpop.gremlin.orientdb.StreamUtils.asStream;
 
@@ -521,6 +521,16 @@ public final class OrientGraph implements Graph {
                 OLogManager.instance().error(this, "Error during context close for db " + url, e);
             }
         }
+    }
+
+    public void createVertexLabel(final String label){
+        String className = labelToClassName(label, OImmutableClass.VERTEX_CLASS_NAME);
+        createVertexClass(className);
+    }
+
+    public void createEdgeLabel(final String label){
+        String className = labelToClassName(label, OImmutableClass.EDGE_CLASS_NAME);
+        createEdgeClass(className);
     }
 
     public void createVertexClass(final String className) {

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientVertex.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientVertex.java
@@ -1,25 +1,5 @@
 package org.apache.tinkerpop.gremlin.orientdb;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static org.apache.tinkerpop.gremlin.orientdb.StreamUtils.asStream;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.apache.tinkerpop.gremlin.structure.Direction;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Property;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.structure.VertexProperty;
-import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
-import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
-
 import com.orientechnologies.common.util.OPair;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.db.record.ORecordElement;
@@ -31,6 +11,25 @@ import com.orientechnologies.orient.core.metadata.schema.OProperty;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.record.impl.ODocumentInternal;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.apache.tinkerpop.gremlin.orientdb.StreamUtils.asStream;
 
 public final class OrientVertex extends OrientElement implements Vertex {
     public static final String CONNECTION_OUT_PREFIX = OrientGraphUtils.CONNECTION_OUT + "_";
@@ -41,12 +40,12 @@ public final class OrientVertex extends OrientElement implements Vertex {
         super(graph, rawElement);
     }
 
-    public OrientVertex(OrientGraph graph, String className) {
-        this(graph, createRawElement(graph, className));
+    public OrientVertex(OrientGraph graph, String label) {
+        this(graph, createRawElement(graph, label));
     }
 
-    protected static ODocument createRawElement(OrientGraph graph, String className) {
-        graph.createVertexClass(className);
+    protected static ODocument createRawElement(OrientGraph graph, String label) {
+        String className = graph.createVertexClass(label);
         return new ODocument(className);
     }
 
@@ -152,8 +151,8 @@ public final class OrientVertex extends OrientElement implements Vertex {
             throw new IllegalStateException("label cannot be null");
 
         // CREATE THE EDGE DOCUMENT TO STORE FIELDS TOO
-        String className = graph.labelToClassName(label, OImmutableClass.EDGE_CLASS_NAME);
-        edge = new OrientEdge(graph, className, outDocument, inDocument, label);
+        //String className = graph.labelToClassName(label, OImmutableClass.EDGE_CLASS_NAME);
+        edge = new OrientEdge(graph, label, outDocument, inDocument, label);
         edge.property(keyValues);
 
         edge.getRawDocument().fields(OrientGraphUtils.CONNECTION_OUT, rawElement, OrientGraphUtils.CONNECTION_IN, inDocument);

--- a/driver/src/test/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraphTest.java
+++ b/driver/src/test/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraphTest.java
@@ -1,5 +1,19 @@
 package org.apache.tinkerpop.gremlin.orientdb;
 
+import com.orientechnologies.orient.core.metadata.schema.OImmutableClass;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.Transaction;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.Map;
+
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.tinkerpop.gremlin.structure.Transaction.CLOSE_BEHAVIOR.COMMIT;
@@ -13,23 +27,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-
-import java.util.Iterator;
-import java.util.Map;
-
-import com.orientechnologies.orient.core.db.OPartitionedDatabasePool;
-import org.apache.tinkerpop.gremlin.structure.Direction;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.Property;
-import org.apache.tinkerpop.gremlin.structure.Transaction;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.structure.VertexProperty;
-import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Test;
-
-import com.google.common.collect.Lists;
 
 public class OrientGraphTest {
 
@@ -287,4 +284,17 @@ public class OrientGraphTest {
         }
     }
 
+    @Test
+    public void checkClassNameConstruction(){
+        String edgeLabel = "edge_label";
+        String vertexLabel = "vertex_label";
+        OrientGraphFactory factory = new OrientGraphFactory("memory:myGraph");
+        OrientGraph graph = factory.getNoTx();
+
+        graph.createVertexLabel(vertexLabel);
+        graph.createEdgeLabel(edgeLabel);
+
+        graph.database().browseClass(OImmutableClass.VERTEX_CLASS_NAME + "_" +vertexLabel);
+        graph.database().browseClass(OImmutableClass.EDGE_CLASS_NAME + "_" + edgeLabel);
+    }
 }

--- a/driver/src/test/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraphTest.java
+++ b/driver/src/test/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraphTest.java
@@ -285,16 +285,16 @@ public class OrientGraphTest {
     }
 
     @Test
-    public void checkClassNameConstruction(){
+    public void checkClassNameConstruction() {
         String edgeLabel = "edge_label";
         String vertexLabel = "vertex_label";
         OrientGraphFactory factory = new OrientGraphFactory("memory:myGraph");
         OrientGraph graph = factory.getNoTx();
 
-        graph.createVertexLabel(vertexLabel);
-        graph.createEdgeLabel(edgeLabel);
+        graph.createVertexClass(vertexLabel);
+        graph.createEdgeClass(edgeLabel);
 
-        graph.database().browseClass(OImmutableClass.VERTEX_CLASS_NAME + "_" +vertexLabel);
+        graph.database().browseClass(OImmutableClass.VERTEX_CLASS_NAME + "_" + vertexLabel);
         graph.database().browseClass(OImmutableClass.EDGE_CLASS_NAME + "_" + edgeLabel);
     }
 }


### PR DESCRIPTION
Using the method `createVertexClass()` required you to prepend "V_" yourself I thought maybe having a new method for creating labels this way could be useful.