### PR TITLE
Implemented OrientGraph#drop

### DIFF
--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
@@ -422,6 +422,14 @@ public final class OrientGraph implements Graph {
     }
 
     /**
+     * (Blueprints Extension) Drops the database
+     */
+    public void drop() {
+        makeActive();
+        getRawDatabase().drop();
+    }
+
+    /**
      * Checks if the Graph has been closed.
      *
      * @return True if it is closed, otherwise false

--- a/driver/src/test/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraphTest.java
+++ b/driver/src/test/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraphTest.java
@@ -302,7 +302,6 @@ public class OrientGraphTest {
     @Test
     public void checkMemoryDrop() {
 
-
         OrientGraphFactory factory = new OrientGraphFactory("memory:_dropDB");
 
         OrientGraph graph = factory.getNoTx();

--- a/driver/src/test/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraphTest.java
+++ b/driver/src/test/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraphTest.java
@@ -1,5 +1,6 @@
 package org.apache.tinkerpop.gremlin.orientdb;
 
+import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.metadata.schema.OImmutableClass;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
@@ -296,5 +297,21 @@ public class OrientGraphTest {
 
         graph.database().browseClass(OImmutableClass.VERTEX_CLASS_NAME + "_" + vertexLabel);
         graph.database().browseClass(OImmutableClass.EDGE_CLASS_NAME + "_" + edgeLabel);
+    }
+
+    @Test
+    public void checkMemoryDrop() {
+
+
+        OrientGraphFactory factory = new OrientGraphFactory("memory:_dropDB");
+
+        OrientGraph graph = factory.getNoTx();
+
+        Assert.assertNotNull(Orient.instance().getStorage("_dropDB"));
+
+        graph.drop();
+
+        Assert.assertNull(Orient.instance().getStorage("_dropDB"));
+
     }
 }

--- a/driver/src/test/java/org/apache/tinkerpop/gremlin/orientdb/gremlintest/OrientGraphProvider.java
+++ b/driver/src/test/java/org/apache/tinkerpop/gremlin/orientdb/gremlintest/OrientGraphProvider.java
@@ -1,24 +1,12 @@
 package org.apache.tinkerpop.gremlin.orientdb.gremlintest;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assume.assumeFalse;
-
-import java.io.File;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-
+import com.google.common.collect.Sets;
+import com.orientechnologies.orient.core.id.ORID;
+import com.orientechnologies.orient.core.id.ORecordId;
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.AbstractGraphProvider;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
-import org.apache.tinkerpop.gremlin.orientdb.OrientEdge;
-import org.apache.tinkerpop.gremlin.orientdb.OrientElement;
-import org.apache.tinkerpop.gremlin.orientdb.OrientGraph;
-import org.apache.tinkerpop.gremlin.orientdb.OrientProperty;
-import org.apache.tinkerpop.gremlin.orientdb.OrientVertex;
-import org.apache.tinkerpop.gremlin.orientdb.OrientVertexProperty;
+import org.apache.tinkerpop.gremlin.orientdb.*;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.FeatureSupportTest.GraphFunctionalityTest;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -26,9 +14,11 @@ import org.apache.tinkerpop.gremlin.structure.GraphTest;
 import org.apache.tinkerpop.gremlin.structure.SerializationTest.GryoTest;
 import org.junit.AssumptionViolatedException;
 
-import com.google.common.collect.Sets;
-import com.orientechnologies.orient.core.id.ORID;
-import com.orientechnologies.orient.core.id.ORecordId;
+import java.io.File;
+import java.util.*;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assume.assumeFalse;
 
 public class OrientGraphProvider extends AbstractGraphProvider {
 
@@ -88,8 +78,13 @@ public class OrientGraphProvider extends AbstractGraphProvider {
 
     @Override
     public void clear(Graph graph, Configuration configuration) throws Exception {
-        if (graph != null)
-            graph.close();
+        if (graph != null) {
+            OrientGraph g = (OrientGraph) graph;
+            if (!g.isClosed()) {
+                g.drop();
+            }
+        }
+
     }
 
     @Override


### PR DESCRIPTION
Hi 
I've implemented graph.drop and used it in  OrientGraphProvider#clear instead of graph.close.
In this way the storages created for the tests are removed from the memory. 
It should make [this](https://github.com/mpollmeier/orientdb-gremlin/pull/74) work.
