### PR TITLE
TP version 3.4.6 to 3.4.7

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <gremlin.version>3.4.6</gremlin.version>
+        <gremlin.version>3.4.7</gremlin.version>
         <project.rootdir>${project.basedir}/../</project.rootdir>
     </properties>
 

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/io/OrientIoRegistry.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/io/OrientIoRegistry.java
@@ -4,8 +4,8 @@ import com.orientechnologies.orient.core.db.record.ridbag.ORidBag;
 import com.orientechnologies.orient.core.id.ORecordId;
 import java.util.Map;
 import org.apache.tinkerpop.gremlin.orientdb.io.graphson.OrientGraphSONV3;
-import org.apache.tinkerpop.gremlin.orientdb.io.kryo.ORecordIdKryoSerializer;
-import org.apache.tinkerpop.gremlin.orientdb.io.kryo.ORidBagKryoSerializer;
+import org.apache.tinkerpop.gremlin.orientdb.io.gryo.ORecordIdGyroSerializer;
+import org.apache.tinkerpop.gremlin.orientdb.io.gryo.ORidBagGyroSerializer;
 import org.apache.tinkerpop.gremlin.structure.io.AbstractIoRegistry;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONIo;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
@@ -19,8 +19,8 @@ public class OrientIoRegistry extends AbstractIoRegistry {
   private static final OrientIoRegistry INSTANCE = new OrientIoRegistry();
 
   private OrientIoRegistry() {
-    register(GryoIo.class, ORecordId.class, new ORecordIdKryoSerializer());
-    register(GryoIo.class, ORidBag.class, new ORidBagKryoSerializer());
+    register(GryoIo.class, ORecordId.class, new ORecordIdGyroSerializer());
+    register(GryoIo.class, ORidBag.class, new ORidBagGyroSerializer());
 
     register(GraphSONIo.class, ORecordId.class, OrientGraphSONV3.INSTANCE);
   }

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/io/gryo/ORecordIdGyroSerializer.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/io/gryo/ORecordIdGyroSerializer.java
@@ -1,4 +1,4 @@
-package org.apache.tinkerpop.gremlin.orientdb.io.kryo;
+package org.apache.tinkerpop.gremlin.orientdb.io.gryo;
 
 import com.orientechnologies.orient.core.id.ORecordId;
 import org.apache.tinkerpop.shaded.kryo.Kryo;
@@ -7,7 +7,7 @@ import org.apache.tinkerpop.shaded.kryo.io.Input;
 import org.apache.tinkerpop.shaded.kryo.io.Output;
 
 /** Created by Enrico Risa on 06/09/2017. */
-public class ORecordIdKryoSerializer extends Serializer<ORecordId> {
+public class ORecordIdGyroSerializer extends Serializer<ORecordId> {
   @Override
   public ORecordId read(
       final Kryo kryo, final Input input, final Class<ORecordId> tinkerGraphClass) {

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/io/gryo/ORidBagGyroSerializer.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/io/gryo/ORidBagGyroSerializer.java
@@ -1,4 +1,4 @@
-package org.apache.tinkerpop.gremlin.orientdb.io.kryo;
+package org.apache.tinkerpop.gremlin.orientdb.io.gryo;
 
 import com.orientechnologies.orient.core.db.record.ridbag.ORidBag;
 import com.orientechnologies.orient.core.id.ORecordId;
@@ -8,7 +8,7 @@ import org.apache.tinkerpop.shaded.kryo.io.Input;
 import org.apache.tinkerpop.shaded.kryo.io.Output;
 
 /** Created by Enrico Risa on 06/09/2017. */
-public class ORidBagKryoSerializer extends Serializer<ORidBag> {
+public class ORidBagGyroSerializer extends Serializer<ORidBag> {
   @Override
   public ORidBag read(final Kryo kryo, final Input input, final Class<ORidBag> tinkerGraphClass) {
     final ORidBag bag = new ORidBag();

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -15,7 +15,7 @@
     <artifactId>orientdb-gremlin-server</artifactId>
 
     <properties>
-        <tinkerpop.version>3.4.6</tinkerpop.version>
+        <tinkerpop.version>3.4.7</tinkerpop.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.rootdir>${project.basedir}/../</project.rootdir>
     </properties>


### PR DESCRIPTION
ODB does not support the latest `3.4.7` TP gremlin-server version as mentioned in the documentation (as also requested by https://github.com/orientechnologies/orientdb-gremlin/issues/174). This leads to the issue that an old Groovy version is loaded that conflicts with a newer one used in `3.4.7`.