### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,9 @@ install:
 #  - mvn install dependency:go-offline -Pskip-formatter -DskipTests=true -q -f driver/pom.xml -Dfailsafe.timeout=0
 
 script:
-  - travis_wait 30 mvn install -f driver/pom.xml -Dfailsafe.timeout=0
-  - travis_wait 30 mvn install -f server/pom.xml -Dfailsafe.timeout=0
+  - mvn install -f driver/pom.xml -Dfailsafe.timeout=0
+  - mvn install -f server/pom.xml -Dfailsafe.timeout=0
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
